### PR TITLE
Support recent node versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,9 @@ module.exports = function(opt) {
                 extension = "scss";
             }
 
-            return fs.writeFile(options.style_path + options.file_name + '.' + extension, content);
+            return fs.writeFile(options.style_path + options.file_name + '.' + extension, content, function(err) {
+                if (err) throw err;
+            });
         });
         return cb();
     }


### PR DESCRIPTION
`fs.writeFile` requires a callback in recent node versions.